### PR TITLE
added LICENSE field to Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,7 @@ use ExtUtils::MakeMaker;
 # the contents of the Makefile that is written.
 WriteMakefile(
     NAME              => 'Cache::Memcached::Fast',
+    LICENSE           => 'perl_5',
     VERSION_FROM      => 'lib/Cache/Memcached/Fast.pm',
     PREREQ_PM         => {
         'Test::More'  =>  0


### PR DESCRIPTION
Added LICENSE field to Makefile.PL with the value 'perl_5'. I chose this value given the description under the COPYRIGHT-AND-LICENSE section for this module I found on MetaCPAN https://metacpan.org/pod/Cache::Memcached::Fast#COPYRIGHT-AND-LICENSE