### PR TITLE
fix for rt-43537: undefined values passed to the multi functions no long...

### DIFF
--- a/Fast.xs
+++ b/Fast.xs
@@ -176,8 +176,8 @@ parse_serialize(pTHX_ Cache_Memcached_Fast *memd, HV *conf)
   if (ps && SvOK(*ps))
     {
       AV *av = (AV *) SvRV(*ps);
-      memd->serialize_method = newSVsv(*safe_av_fetch(av, 0, 0));
-      memd->deserialize_method = newSVsv(*safe_av_fetch(av, 1, 0));
+      memd->serialize_method = newSVsv(*safe_av_fetch(aTHX_ av, 0, 0));
+      memd->deserialize_method = newSVsv(*safe_av_fetch(aTHX_ av, 1, 0));
     }
 
   if (! memd->serialize_method)
@@ -217,8 +217,8 @@ parse_compress(pTHX_ Cache_Memcached_Fast *memd, HV *conf)
   if (ps && SvOK(*ps))
     {
       AV *av = (AV *) SvRV(*ps);
-      memd->compress_method = newSVsv(*safe_av_fetch(av, 0, 0));
-      memd->decompress_method = newSVsv(*safe_av_fetch(av, 1, 0));
+      memd->compress_method = newSVsv(*safe_av_fetch(aTHX_ av, 0, 0));
+      memd->decompress_method = newSVsv(*safe_av_fetch(aTHX_ av, 1, 0));
     }
   else if (memd->compress_threshold > 0)
     {
@@ -844,14 +844,14 @@ set_multi(memd, ...)
               croak("Not an array reference");
 
             av = (AV *) SvRV(sv);
-            key = SvPV_stable_storage(aTHX_ *safe_av_fetch(av, arg, 0), &key_len);
+            key = SvPV_stable_storage(aTHX_ *safe_av_fetch(aTHX_ av, arg, 0), &key_len);
             ++arg;
             if (ix == CMD_CAS)
               {
-                cas = SvUV(*safe_av_fetch(av, arg, 0));
+                cas = SvUV(*safe_av_fetch(aTHX_ av, arg, 0));
                 ++arg;
               }
-            sv = *safe_av_fetch(av, arg, 0);
+            sv = *safe_av_fetch(aTHX_ av, arg, 0);
             ++arg;
             sv = serialize(aTHX_ memd, sv, &flags);
             sv = compress(aTHX_ memd, sv, &flags);
@@ -1062,7 +1062,7 @@ incr_multi(memd, ...)
                   croak("Not an array reference");
 
                 av = (AV *) SvRV(sv);
-                key = SvPV_stable_storage(aTHX_ *safe_av_fetch(av, 0, 0), &key_len);
+                key = SvPV_stable_storage(aTHX_ *safe_av_fetch(aTHX_ av, 0, 0), &key_len);
                 if (av_len(av) >= 1)
                   {
                     /* increment doesn't have to be defined.  */
@@ -1192,7 +1192,7 @@ delete_multi(memd, ...)
                   croak("Not an array reference");
 
                 av = (AV *) SvRV(sv);
-                key = SvPV_stable_storage(aTHX_ *safe_av_fetch(av, 0, 0), &key_len);
+                key = SvPV_stable_storage(aTHX_ *safe_av_fetch(aTHX_ av, 0, 0), &key_len);
                 if (av_len(av) >= 1)
                   {
                     /* delay doesn't have to be defined.  */
@@ -1315,7 +1315,7 @@ touch_multi(memd, ...)
               croak("Not an array reference");
 
             av = (AV *) SvRV(sv);
-            key = SvPV_stable_storage(aTHX_ *safe_av_fetch(av, arg, 0), &key_len);
+            key = SvPV_stable_storage(aTHX_ *safe_av_fetch(aTHX_ av, arg, 0), &key_len);
             ++arg;
 
             if (av_len(av) >= 1)

--- a/MANIFEST
+++ b/MANIFEST
@@ -16,6 +16,7 @@ t/big_value.t
 t/commands.t
 t/key_ref.t
 t/magic.t
+t/malformed.t
 t/namespace.t
 t/nowait.t
 t/noreply.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,8 @@ WriteMakefile(
     NAME              => 'Cache::Memcached::Fast',
     VERSION_FROM      => 'lib/Cache/Memcached/Fast.pm',
     PREREQ_PM         => {
-        'Test::More'  =>  0
+       'Test::More'  =>  0,
+       'Test::Exception' => 0,
     },
     ABSTRACT_FROM     => 'lib/Cache/Memcached/Fast.pm',
     AUTHOR            => 'Tomash Brechko <tomash.brechko@gmail.com>',

--- a/t/malformed.t
+++ b/t/malformed.t
@@ -1,0 +1,49 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin";
+use Memd;
+use Test::Exception;
+use Test::More;
+
+if ($Memd::memd) {
+    plan tests => 34;
+} 
+else {
+    plan skip_all => 'Not connected';
+}
+
+# add some values to the server
+foreach ( 1 .. 3 ) {
+   my ($key, $val) = ("k$_", "v$_");
+   ok($Memd::memd->set($key, $val), "set '$key' to '$val'");
+   is($Memd::memd->get($key), $val, "fetch '$key'");
+}
+
+# test that the no values are set on the server if one or more
+# values in a call to set_multi are not defined
+# or if the argument to set_multi is not an array reference
+my @tests = (
+   [ ['k1', 'new v1'], [], ['k2', 'new k2'] ],
+   [ [], ['k1', 'new v1'], ['k2', 'new k2'] ],
+   [ ['k1', 'new v1'], ['k2', 'new k2'], [] ],
+   [ [undef, 'new v1'], ['k2', 'new v2'] ],
+   [ ['k1', 'new v1'], ['k2', undef] ],
+   [ ['k2', 'new v1'], undef ],
+   [ undef, ['k2', 'new v2'] ],
+);
+foreach my $test ( @tests ) {
+   dies_ok {
+      # no values should be updated after this set_multi
+      $Memd::memd->set_multi( @$test );   
+   } 'Croaked on empty value passed to set_multi';
+
+   foreach ( 1 .. 3 ) {
+      my ($key, $val) = ("k$_", "v$_");
+      is($Memd::memd->get($key), $val, "fetch '$key'");
+   }
+}
+


### PR DESCRIPTION
This patch fixes [rt-43537](https://rt.cpan.org/Public/Bug/Display.html?id=43537):

Calls to set_multi that contained an undefined value caused segmentation faults. The root cause of this was the de-referencing of a call to [```av_fetch()```](http://perldoc.perl.org/perlapi.html#Array-Manipulation-Functions) which returned a NULL pointer. 

To fix this a new function, ```safe_av_fetch()```, was added to Fast.xs that checks the result of ```av_fetch``` for a NULL pointer or a pointer that does not pass an [```SvOK()```](http://perldoc.perl.org/perlapi.html#SV-Manipulation-Functions) check. If such a value is encountered ```safe_av_fetch()``` croaks.

A new test t/malformed.t was added to test this new functionality. It adds three values to the server, then submits a series calls to ```set_mutli()``` with invalid arguments (in varying positions). It verifies that none of these calls changes the values of the keys on the server.